### PR TITLE
camlidl requires ocaml-pcre

### DIFF
--- a/camlidl.rb
+++ b/camlidl.rb
@@ -8,6 +8,11 @@ class Camlidl < Formula
   depends_on 'objective-caml'
   depends_on 'besport/ocaml/ocaml-pcre'
 
+  def patches
+    # Fixing the hardcoded /lib/cpp
+    DATA
+  end
+
   def install
     homebrew_prefix_stdlib = `ocamlc -where`.gsub /\n/, ""
     prefix_stdlib = homebrew_prefix_stdlib.gsub HOMEBREW_PREFIX, prefix
@@ -19,3 +24,15 @@ class Camlidl < Formula
     system "make install BINDIR=#{bin}/ OCAMLLIB=#{prefix_stdlib}"
   end
 end
+__END__
+--- a/config/Makefile.unix	2012-12-12 02:00:48.000000000 -0800
++++ b/config/Makefile.unix	2012-12-12 02:00:52.000000000 -0800
+@@ -19,7 +19,7 @@
+ 
+ # How to invoke the C preprocessor
+ # Works on most Unix systems:
+-CPP=/lib/cpp
++CPP=cpp
+ # Alternatives:
+ # CPP=cpp
+ # CPP=/usr/ccs/lib/cpp


### PR DESCRIPTION
ocaml-pcre can be found in the besport/ocaml tap

Without it, I was getting this kind of error:

```
Error: Unbound module Prefix
make[1]: *** [lexpr.cmi] Error 2
```
