### PR TITLE
Update ltl3ba to 1.1.2

### DIFF
--- a/ltl3ba.rb
+++ b/ltl3ba.rb
@@ -2,13 +2,12 @@ require 'formula'
 
 class Ltl3ba < Formula
   homepage 'http://sourceforge.net/projects/ltl3ba/'
-  url 'http://sourceforge.net/projects/ltl3ba/files/ltl3ba/1.0/ltl3ba-1.0.2.tar.gz'
-  sha1 'd6a745a7c2712f7cc88ffc4f96b9574692e6fd47'
+  url 'https://sourceforge.net/projects/ltl3ba/files/ltl3ba/1.1/ltl3ba-1.1.2.tar.gz'
+  sha256 '42ae878b43acd7a712b1bad834beb4ff21319f88486451bd8d8d9450b6089779'
 
   depends_on 'buddy'
 
   def install
-    inreplace 'Makefile', ' -static', ''
     system "make", "BUDDY_INCLUDE=#{HOMEBREW_PREFIX}/include/",
                    "BUDDY_LIB=#{HOMEBREW_PREFIX}/lib/"
     bin.install "ltl3ba"


### PR DESCRIPTION
This commit updates the version of ltl3ba. 1.0.2 did not compile on my
machine, but 1.1.2 does work. Additionally, this commit updates the sha
checksum to the sha256 algorithm, which is preferred by Homebrew now.