### PR TITLE
Add to path to allow ./configure to find cython

### DIFF
--- a/boolector.rb
+++ b/boolector.rb
@@ -24,6 +24,7 @@ class Boolector < Formula
     venv_root = libexec/"venv"
     xy = Language::Python.major_minor_version "python3"
     ENV.prepend_create_path "PYTHONPATH", "#{venv_root}/lib/python#{xy}/site-packages"
+    ENV.prepend_path "PATH", "#{venv_root}/bin"
     venv = virtualenv_create(venv_root, "python3")
     venv.pip_install resource("Cython")
 


### PR DESCRIPTION
Boolector's `./configure.sh` script looks for cython, and unless the virtualenv bin is present on $PATH, it can't find it and fails.

With this addition, the formula builds successfully for me on macOS 11.1.