### PR TITLE
Update cvc5 to 1.0.1

### DIFF
--- a/cvc5.rb
+++ b/cvc5.rb
@@ -1,13 +1,23 @@
-require 'formula'
-
 class Cvc5 < Formula
-  homepage 'https://cvc5.github.io'
-  desc 'CVC5 is an efficient open-source automatic theorem prover for satisfiability modulo theories (SMT) problems.'
-  url 'https://github.com/cvc5/cvc5/releases/download/cvc5-1.0.0/cvc5-macOS'
-  sha256 '43420009f1b305f74d3c92aaf64ff3ce39e85e8601d4b0dc6c7dc33fe7c5be6d'
-  version '1.0.0'
+  desc "Efficient open-source automatic theorem prover for SMT problems"
+  homepage "https://cvc5.github.io"
+  version "1.0.1"
+
+  # frozen_string_literal: true
+  #
+  if Hardware::CPU.intel?
+    url "https://github.com/cvc5/cvc5/releases/download/cvc5-1.0.1/cvc5-macOS"
+    sha256 "67c32310226177ec36d60d377f31eea211c2543bd6487b5c39c39bf9547df568"
+  else
+    url "https://github.com/cvc5/cvc5/releases/download/cvc5-1.0.1/cvc5-macOS-arm64"
+    sha256 "89b9df4307ff6401c3487b1df166ea77eb7f91b8fd91d52376a1b7660f5930ba"
+  end
 
   def install
-    bin.install "cvc5-macOS" => "cvc5"
+    if Hardware::CPU.intel?
+      bin.install "cvc5-macOS" => "cvc5"
+    else
+      bin.install "cvc5-macOS-arm64" => "cvc5"
+    end
   end
 end


### PR DESCRIPTION
* The formula downloads the appropriate (Intel or M1) binary for the user's architecture
* I also removed most issues pointed out by "brew audit"