### PR TITLE
Update mathsat to 5.6.9

### DIFF
--- a/mathsat.rb
+++ b/mathsat.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Mathsat < Formula
   homepage 'http://mathsat.fbk.eu/index.html'
-  url 'https://mathsat.fbk.eu/release/mathsat-5.6.8-osx.tar.gz'
-  version '5.6.8'
-  sha256 'b1f33adf99c2a856d5f8c81b3864026ef676470931b196d2cfcc2fe1e621fa19'
+  url 'https://mathsat.fbk.eu/release/mathsat-5.6.9-osx.tar.gz'
+  version '5.6.9'
+  sha256 '043af0f6501c3adb0c75702282925a72b6ca148b2b2e20b2962e875cad6c158a'
 
   depends_on 'gmp'
   depends_on 'python'


### PR DESCRIPTION
As the title implies, this PR updates the mathsat formula.

By the way, there is something strange going on with the Python bindings. The instruction `import mathsat`
fails with the following message:

```
ImportError: dlopen(/opt/homebrew/lib/python3.10/site-packages/_mathsat.cpython-310-darwin.so, 0x0002): Library not loaded: '/opt/local/lib/libgmp.10.dylib'
```

I will try and see if something can be done to fix this.